### PR TITLE
Add maven compiler source/target version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,15 @@
 							</execution>
 						</executions>
 					</plugin>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-compiler-plugin</artifactId>
+						<version>3.1</version>
+						<configuration>
+							<source>1.5</source>
+							<target>1.5</target>
+						</configuration>
+					</plugin>
 				</plugins>
 			</build>
 		</profile>


### PR DESCRIPTION
I had to add the maven compiler source/target versions to get the command `mvn package` to work
